### PR TITLE
Testes unitários para funções de formatação Intl

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "axios": "^0.21.1",
+    "intl": "^1.2.5",
     "miragejs": "^0.1.41",
     "polished": "^4.1.1",
     "react": "^17.0.1",
@@ -17,6 +18,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "@types/intl": "^1.2.0",
     "@types/jest": "^26.0.15",
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",

--- a/src/components/TransactionsTable/index.tsx
+++ b/src/components/TransactionsTable/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { api } from "../../services/api";
+import { formatCurrency, formatDate } from "../../utils/intl";
 import { Container } from "./styles";
 
 interface Transaction {
@@ -38,17 +39,12 @@ export function TransactionsTable() {
             <tr key={transaction.id}>
               <td>{transaction.title}</td>
               <td className={transaction.type}>
-                {new Intl.NumberFormat("pt-BR", {
-                  style: "currency",
-                  currency: "BRL",
-                }).format(transaction.amount)}
+                {formatCurrency(transaction.amount)}
               </td>
               <td>{transaction.category}</td>
 
               <td>
-                {new Intl.DateTimeFormat("pt-BR").format(
-                  new Date(transaction.createdAt)
-                )}
+                {formatDate(new Date(transaction.createdAt))}
               </td>
             </tr>
           ))}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,10 @@
+import '@testing-library/jest-dom/extend-expect';
+
+import IntlPolyfill from 'intl';
+
+if (global.Intl) {
+  Intl.NumberFormat = IntlPolyfill.NumberFormat;
+  Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
+} else {
+  global.Intl = require('intl');
+}

--- a/src/utils/intl.spec.ts
+++ b/src/utils/intl.spec.ts
@@ -1,0 +1,14 @@
+import { formatCurrency, formatDate } from './intl';
+
+describe('intl', () => {
+  it('should format currency', () => {
+    expect(formatCurrency(100)).toContain('R$100,00');
+    expect(formatCurrency(-100)).toContain('-R$100,00');
+    expect(formatCurrency(999999999.55)).toContain('R$999.999.999,55');
+  });
+
+  it('should format date', () => {
+    expect(formatDate(new Date('2020/05/01'))).toContain('01/05/2020');
+    expect(formatDate(new Date('1850/12/05'))).toContain('05/12/1850');
+  });
+});

--- a/src/utils/intl.ts
+++ b/src/utils/intl.ts
@@ -1,0 +1,10 @@
+export function formatCurrency(value: number) {
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  }).format(value);
+}
+
+export function formatDate(date: Date) {
+  return new Intl.DateTimeFormat('pt-BR').format(new Date(date));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,6 +1787,11 @@
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
   integrity sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA==
 
+"@types/intl@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/intl/-/intl-1.2.0.tgz#1245511f13064402087979f498764611a3c758fc"
+  integrity sha512-BP+KwmOvD9AR5aoxnbyyPr3fAtpjEI/bVImHsotmpuC43+z0NAmjJ9cQbX7vPCq8XcvCeAVc8E3KSQPYNaPsUQ==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -5916,6 +5921,11 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+intl@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
+  integrity sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94=
 
 ip-regex@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Como essas funções de formatar data, moedas etc.. geralmente são muito reutilizadas, achei bacana extrair a implementação dentro do componente e centraliza-la dentro de uma pasta de utilidades (utils).

Aproveitei e desenvolvi alguns testes unitários para validar o funcionamento. Para isso criei um arquivo de setup de testes para trabalhar bem com intl dentro dos testes, da mesma forma que é feito na web.
Segui essa solução baseada nessa issue do react testing library https://github.com/testing-library/react-testing-library/issues/328